### PR TITLE
Add Google zero-click login implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,105 @@
 **Plugin Summary**
 
 For more information, please see: **url to meta topic**
+
+Currently, the plugin only supports zero-click logins for when Google is the
+only configured SSO provider.
+
+## Manually testing the plugin functionality in development
+
+If you want to manually test the functionality of this plugin, you must create a
+real Google OAuth2 Client in [Google Cloud](https://cloud.google.com). If you
+already have Google Cloud Console access, you can go to
+[console.cloud.google.com/auth/clients](https://console.cloud.google.com/auth/clients)
+to get started.
+
+### Setting up
+
+In Google Cloud:
+
+1. Create a new Google OAuth2 Client with an application type of **Web application**.
+2. Add your **authorised JavaScript origins** and **authorised redirect URIs**.
+   For a typical Discourse development environment setup:
+   - Authorised JavaScript origin: `http://127.0.0.1:4200`
+   - Authorised redirect URI: `http://127.0.0.1:4200/auth/google_oauth2/callback`
+2. On creation, copy down the **client ID** and **client secret** somewhere
+   secure like a password manager--or directly into your local Discourse configuration
+   settings.
+
+In the Discourse web application:
+
+1. Log in as an admin user.
+2. Navigate to **[Admin -> Community -> Login &
+   authentication](http://127.0.0.1:4200/admin/config/login-and-authentication)**.
+3. Uncheck the **Enable local logins** checkbox.
+4. Check the **Enable Google OAuth2 logins** checkbox.
+5. Enter **Google OAuth2 client ID** and **Google OAuth2 client secret** values
+   you retrieved from Google Cloud.
+6. Ensure all _all_ of the other login providers have been disabled (i.e.
+   **Enable Twitter logins** should be **disabled**.)
+
+### Test scenarios
+
+After completing the setup described above, you can test the functionality of
+this plugin using the following scenarios as a guide.
+
+**Scenario 1: No Google SSO session.**
+
+1. Navigate to [accounts.google.com](https://accounts.google.com) and confirm
+   you are logged out of all Google accounts.
+2. In your browser settings, ensure you have none or have deleted all cookies
+   for the `127.0.0.1` domain.
+3. Navigate to any page of the Discourse webapp (i.e. `/` or `/latest`) and
+   ensure you remain logged out and that the pages do not raise exceptions.
+4. Navigate to `/login` and see the normal Google login page.
+5. Navigate to `/signup` and see the normal Google signup page.
+
+Because this plugin does not make any changes to the login or signup flow, we
+don't need to test beyond this. Discourse's core test suite gives us confidence
+that these flows continue to work.
+
+**Scenario 2: Logged in with a Google account that is not associated with a
+DWW without an existing iscourse user account.**
+
+Note that if you need to check whether your Google account is associated with a
+Discourse user you can do this from a Rails console:
+
+```ruby
+me = User.find_by(email: MY_EMAIL)
+my_associated_google_accounts =
+  me.user_associated_accounts.where(provider_name: "google_oauth2")
+my_associated_google_accounts.destroy_all
+```
+
+2. Navigate to [accounts.google.com](https://accounts.google.com) and confirm
+   you are logged into a Google account.
+3. In your browser settings, ensure you have none or have deleted all cookies
+   for the `127.0.0.1` domain.
+4. Navigate to any page of the Discourse webapp (i.e. `/` or `/latest`) and
+   ensure you remain logged out and that the pages do not raise exceptions.
+5. Navigate to `/login` and expect to be redirected to `/signup` with your
+   Google email pre-filled.
+
+**Scenario 3: Logged in with a Google account that is associated with an
+existing Discourse user account.**
+
+Ensure your Google account is associated with a Discourse user account before
+starting (see **Scenario 2** for guidance).
+
+1. Navigate to [accounts.google.com](https://accounts.google.com) and confirm
+   you are logged into a Google account.
+2. In your browser settings, ensure you have none or have deleted all cookies
+   for the `127.0.0.1` domain.
+3. Navigate to any page of the Discourse webapp (i.e. `/` or `/latest`) and
+   ensure you have been logged into your existing Discourse user account.
+
+**Scenario 4: Allow browsing Discourse logged out.**
+
+One way to test this scenario is to go through **Scenario 3** to get set up.
+
+1. In your browser settings, ensure you **do** have cookies for the `127.0.0.1`
+   domain (that are related to your Discourse instance, not some other
+   application in development).
+2. Navigate to any page of the Discourse webapp (i.e. `/` or `/latest`).
+3. If you are logged in, log out. If you are logged out, remain logged out.
+4. Browse to other pages and ensure you remain logged out.

--- a/lib/zero_click_sso/application_controller_override.rb
+++ b/lib/zero_click_sso/application_controller_override.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module ZeroClickSso
+  module ApplicationControllerOverride
+    extend ActiveSupport::Concern
+
+    prepended do
+      before_action :attempt_zero_click_sso_login
+
+      after_action :mark_as_zero_click_sso_attempted
+    end
+
+    private
+
+    def attempt_zero_click_sso_login
+      return unless request.format.html? && !is_api?
+      return if session[ZeroClickSso::ATTEMPTED_SESSION_KEY]
+
+      return unless ZeroClickSso.attemptable?
+      return if ZeroClickSso::IGNORED_ROUTES.include?(request.path)
+      return if request.path.start_with?(::ZeroClickSso::AUTH_ROUTES_PREFIX)
+
+      cookies[:destination_url] = destination_url
+      redirect_to path("/auth/#{Discourse.enabled_authenticators.first.name}?zero-click=yes")
+    end
+
+    def mark_as_zero_click_sso_attempted
+      session[ZeroClickSso::ATTEMPTED_SESSION_KEY]||= "true"
+    end
+  end
+end

--- a/lib/zero_click_sso/google_oauth2_authenticator_override.rb
+++ b/lib/zero_click_sso/google_oauth2_authenticator_override.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module ZeroClickSso
+  # Overrides the Google OAuth2 middleware registration built into Discourse.
+  #
+  # In an ideal world, we would be able to call `super` to get the built-in
+  # functionality and then only add the additional functional required for
+  # our plugin, but the lambda makes this more difficult, so I've chosen to
+  # override the method entirely, for clarity in the plugin source.
+  #
+  # See the inline comments for details about the plugin functionality.
+  module GoogleOAuth2AuthenticatorOverride
+    def register_middleware(omniauth)
+      options = {
+        setup:
+          lambda do |env|
+            opts = env["omniauth.strategy"].options
+            opts[:client_id] = SiteSetting.google_oauth2_client_id
+            opts[:client_secret] = SiteSetting.google_oauth2_client_secret
+
+            if (google_oauth2_hd = SiteSetting.google_oauth2_hd).present?
+              opts[:hd] = google_oauth2_hd
+            end
+
+            if (google_oauth2_prompt = SiteSetting.google_oauth2_prompt).present?
+              opts[:prompt] = google_oauth2_prompt.gsub("|", " ")
+            end
+            opts[:client_options][:connection_build] = lambda do |builder|
+              if SiteSetting.google_oauth2_verbose_logging
+                builder.response :logger,
+                                 Rails.logger,
+                                 { bodies: true, formatter: Auth::OauthFaradayFormatter }
+              end
+              builder.request :url_encoded
+              builder.adapter FinalDestination::FaradayAdapter
+            end
+            opts[:skip_jwt] = true
+
+            # The following conditions have been added for the plugin. We want
+            # to inject the OpenID Connect `prompt` parameter with a value of
+            # `none` to allow for silent, zero-click logins from any route the
+            # user visits (other than `/login` and `/signup`).
+            request = ActionDispatch::Request.new(env)
+
+            is_authorization_endpoint =
+              env["PATH_INFO"] == env["omniauth.strategy"].request_path
+            is_zero_click_attempt = request.params["zero-click"] == "yes"
+
+            if ZeroClickSso.attemptable? && (is_authorization_endpoint && is_zero_click_attempt)
+              opts[:prompt] = "none"
+            else
+              opts[:prompt] = google_oauth2_prompt.gsub("|", " ")
+            end
+          end,
+      }
+      omniauth.provider :google_oauth2, options
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,9 +18,17 @@ module ::ZeroClickSso
   AUTH_ROUTES_PREFIX = "/auth/"
   IGNORED_ROUTES = ["/login", "/signup"]
 
+  # A list of supported SSO providers that this plugin supports and can attempt
+  # a zero-click login for.
+  SUPPORTED_PROVIDERS = ["google_oauth2"]
+
   def self.attemptable?
     return false if SiteSetting.enable_local_logins?
     return false unless Discourse.enabled_authenticators.one?
+
+    enabled_provider = Discourse.enabled_authenticators.first
+    return false if SUPPORTED_PROVIDERS.exclude?(enabled_provider.name)
+
     true
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,10 +12,67 @@ enabled_site_setting :zero_click_sso_enabled
 
 module ::ZeroClickSso
   PLUGIN_NAME = "discourse-zero-click-sso"
+
+  ATTEMPTED_SESSION_KEY = :skip_zero_click_sso_attempts
+
+  AUTH_ROUTES_PREFIX = "/auth/"
+  IGNORED_ROUTES = ["/login", "/signup"]
+
+  def self.attemptable?
+    return false if SiteSetting.enable_local_logins?
+    return false unless Discourse.enabled_authenticators.one?
+    true
+  end
 end
 
+require_relative "lib/zero_click_sso/application_controller_override"
+require_relative "lib/zero_click_sso/google_oauth2_authenticator_override"
 require_relative "lib/zero_click_sso/engine"
 
 after_initialize do
-  # Code which should run after Rails has finished booting
+  ApplicationController.prepend(ZeroClickSso::ApplicationControllerOverride)
+  Auth::GoogleOAuth2Authenticator.prepend(ZeroClickSso::GoogleOAuth2AuthenticatorOverride)
+
+  # Handle the additional OAuth2 error types required for good zero-click login
+  # user experience by extending the Discourse application's failure handler.
+  original_omniauth_failure_handler = OmniAuth.config.on_failure
+
+  OmniAuth.config.on_failure = Proc.new do |env|
+    exception = env["omniauth.error"]
+
+    # If the error is not OAuth2 callback-related, we can continue using the
+    # application's failure handler.
+    unless exception.is_a?(OmniAuth::Strategies::OAuth2::CallbackError)
+      next original_omniauth_failure_handler.call(env)
+    end
+
+    error_code = exception.message.to_sym
+
+    # "immediate_failed" is Google's error code in scenarios where no user could
+    # be automatically selected without prompting the OAuth login consent flow.
+    # This error code should only be returned if the application requested OAuth2
+    # authentication with a `prompt=none` parameter value.
+    #
+    #   Docs: https://developers.google.com/identity/sign-in/web/reference
+    #
+    # In the context of this plugin, "immediate_failed" indicates that a
+    # zero-click login attempt failed. It likely failed because:
+    #
+    # - The browser has no current Google SSO session.
+    # - The browser's Google SSO session does not map to any existing  user for
+    #   the current Discourse instance.
+    #
+    # So we want to suppress any error message and let the user continue
+    # browsing at their destination URL.
+    if error_code == :immediate_failed
+      request = ActionDispatch::Request.new(env)
+      origin = request.cookies["destination_url"] || "/"
+
+      request.session[ZeroClickSso::ATTEMPTED_SESSION_KEY] = "true"
+
+      next [302, {"Location" => origin, "Content-Type" => "text/html"}, []]
+    else
+      OmniAuth::FailureEndpoint.call(env)
+    end
+  end
 end

--- a/spec/oauth2_strategy_override.rb
+++ b/spec/oauth2_strategy_override.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# In order to simulate zero-click login failures in a realistic way so that the
+# Discourse core features shared examples can be run successfully, I needed to
+# change the behaviour of OmniAuth's `OmniAuth::Strategy#mock_callback_call`.
+#
+# It could be great to attempt upstreaming this change to OmniAuth so that
+# developers can use OmniAuth's test mode for a larger set of tests.
+module OmniAuth::Strategies::OAuth2TestOverride
+  def mock_callback_call
+    setup_phase
+    @env['omniauth.origin'] = session.delete('omniauth.origin')
+    @env['omniauth.origin'] = nil if env['omniauth.origin'] == ''
+    @env['omniauth.params'] = session.delete('omniauth.params') || {}
+
+    mocked_auth = OmniAuth.mock_auth_for(name.to_s)
+    if mocked_auth.is_a?(Symbol)
+      # For the purposes of this plugin, we need only simulate `CallbackError`s.
+      # But if we were to upstream this, this would need to be refactored.
+      mocked_exception =
+        OmniAuth::Strategies::OAuth2::CallbackError.new(:immediate_failed)
+
+      # In OmniAuth's version of this method, `#fail!` is called without an
+      # exception argument, which isn't realistic.
+      fail!(mocked_auth, mocked_exception)
+    else
+      @env['omniauth.auth'] = mocked_auth
+      OmniAuth.config.before_callback_phase.call(@env) if OmniAuth.config.before_callback_phase
+      call_app!
+    end
+  end
+
+  OmniAuth::Strategies::OAuth2.prepend self
+end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe ZeroClickSso do
+  describe ".attemptable?" do
+    subject { ZeroClickSso.attemptable? }
+
+    context "when local logins are enabled" do
+      before { SiteSetting.enable_local_logins = true }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when there are no enabled authenticators" do
+      before do
+        SiteSetting.enable_local_logins = false
+        allow(Discourse).to receive(:enabled_authenticators).and_return([])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when there are multiple enabled authenticators" do
+      before do
+        SiteSetting.enable_local_logins = false
+        authenticator1 = instance_double("Auth::ManagedAuthenticator", name: "google_oauth2")
+        authenticator2 = instance_double("Auth::ManagedAuthenticator", name: "github")
+        allow(Discourse).to receive(:enabled_authenticators).and_return(
+          [authenticator1, authenticator2],
+        )
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when there is one enabled authenticator but it's not supported" do
+      before do
+        SiteSetting.enable_local_logins = false
+        authenticator = instance_double("Auth::ManagedAuthenticator", name: "unsupported_provider")
+        allow(Discourse).to receive(:enabled_authenticators).and_return([authenticator])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when all conditions are met" do
+      before do
+        SiteSetting.enable_local_logins = false
+        authenticator = instance_double("Auth::ManagedAuthenticator", name: "google_oauth2")
+        allow(Discourse).to receive(:enabled_authenticators).and_return([authenticator])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+end

--- a/spec/system/core_features_spec.rb
+++ b/spec/system/core_features_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../oauth2_strategy_override"
+
 # Parts of the core features examples can be skipped like so:
 #   it_behaves_like "having working core features", skip_examples: %i[login likes]
 #
@@ -12,4 +14,38 @@ RSpec.describe "Core features", type: :system do
   before { enable_current_plugin }
 
   it_behaves_like "having working core features"
+
+  context "when Google is the sole-enabled authentication provider" do
+    before do
+      OmniAuth.config.test_mode = true
+
+      SiteSetting.enable_google_oauth2_logins = true
+      SiteSetting.enable_local_logins = false
+      SiteSetting.enable_local_logins_via_email = false
+
+      # For the purpose of testing that core features continue to work when the
+      # plugin is enabled and configured as intended, we will mock Google's
+      # "immediate_failed" callback response in a realistic way. This ensures our
+      # plugin's `ApplicationController` overrides don't interfere with the stock
+      # feature-set.
+      OmniAuth.config.mock_auth[:google_oauth2] = :immediate_failed
+    end
+
+    after do
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:google_oauth2] = nil
+    end
+
+    context "when the user has a session on Discourse" do
+      before do
+        visit "/"
+      end
+
+      it_behaves_like "having working core features", skip_examples: [:login]
+    end
+
+    context "when the user does not have a session on Discourse" do
+      it_behaves_like "having working core features", skip_examples: [:login]
+    end
+  end
 end

--- a/spec/system/zero_click_logins_spec.rb
+++ b/spec/system/zero_click_logins_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "../oauth2_strategy_override"
+
+# Some of the tests in this file might not look like valuable tests, but I swear
+# to you that they were helpful in debugging multiple (bad) redirects as well as
+# issues with sessions and cookies that the plugin uses to figure out whether a
+# zero-click login is attemptable.
+RSpec.describe "Zero-click logins", type: :system do
+  before { enable_current_plugin }
+
+  context "when Google is the sole-enabled authentication provider" do
+    before do
+      OmniAuth.config.test_mode = true
+
+      SiteSetting.enable_google_oauth2_logins = true
+      SiteSetting.enable_local_logins = false
+      SiteSetting.enable_local_logins_via_email = false
+    end
+
+    after do
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:google_oauth2] = nil
+    end
+
+    context "when the user has no session on Discourse" do
+      context "when the user's SSO session does not exist or is not associated with a Discourse user" do
+        before do
+      	  # OmniAuth in test mode will always succeed to authenticate unless we
+      	  # explicitly mock the auth to be a symbol. It would be great to do
+      	  # end-to-end integration tests with a real Google OAuth2 client ID and
+      	  # secret, but I need to defer doing that work for now. The next best
+      	  # thing is to use `:immediate_failed`, which is what I have observed in
+      	  # development as the response error for zero-click logins when the user
+      	  # does not have a Discourse account associated with their Google
+      	  # account.
+      	  #
+      	  # Note that "immediate_failed" is returned by Google both the following cases:
+      	  #
+      	  #  - That the user's current Google SSO session exists but is not
+      	  #    associated with a Discourse user.
+      	  #  - That the user has no current Google SSO session.
+          OmniAuth.config.mock_auth[:google_oauth2] = :immediate_failed
+        end
+
+        it "allows the user to view the homepage without interruption" do
+          visit "/"
+          expect(page).to have_current_path "/", ignore_query: true
+        end
+
+        it "allows the user to view some other page without interruption" do
+          visit "/latest"
+          expect(page).to have_current_path "/latest", ignore_query: true
+        end
+      end
+
+      context "when the user has a Google SSO session that is associated with a Discourse user" do
+        fab!(:user)
+        let(:fake_provider_uid) { "12345" }
+
+        before do
+          UserAssociatedAccount.create!(
+            user: user,
+            provider_name: "google_oauth2",
+            provider_uid: fake_provider_uid,
+            info: {email: user.email, name: user.name},
+            credentials: {},
+            extra: {},
+            last_used: Time.now
+          )
+          OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+            provider: "google_oauth2",
+            uid: fake_provider_uid,
+            info: OmniAuth::AuthHash::InfoHash.new(
+              email: user.email,
+              name: user.name
+            ),
+            extra: {raw_info: {email_verified: true}}
+          )
+        end
+
+        it "logs in the user with zero clicks required" do
+          visit "/"
+          expect(page).to have_css(".current-user", visible: true)
+        end
+
+        it "allows the user to log out and browse anonymously after a zero-click login" do
+          visit "/"
+          expect(page).to have_css(".current-user", visible: true)
+
+          click_on "Notifications and account"
+          click_on "Profile"
+          click_on "Log Out"
+          expect(page).not_to have_css(".current-user")
+
+          visit "/latest"
+          expect(page).not_to have_css(".current-user")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This adds the first zero-click login implementation to this plugin.

### Testing

Writing automated integration tests that truly go through the OAuth2 authentication flow with a real third-party provider like Google can be tricky. The system tests may get flaky due to real-time encryption and timing issues. For this project, I have deferred doing that work and instead:

1. Provided system tests that use OmniAuth's provided test mode.
2. Provided manual testing instructions for developers who want to verify the functionality of this plugin. See the diff of the README changes in this pull request.

As the author I will also verify that I have personally run through the manual testing scenarios I documented:

- [x] Scenario 1
- [x] Scenario 2
- [x] Scenario 3
- [x] Scenario 4
